### PR TITLE
Support both GNU/BSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,9 +52,15 @@ if [ -e src/smbios.txt ]; then
 else
     . src/smbios-sample.txt
 fi
-sed -i "" -e "s/MLB_PLACEHOLDER/$MLB/" \
-          -e "s/Serial_PLACEHOLDER/$SystemSerialNumber/" \
-          -e "s/SmUUID_PLACEHOLDER/$SystemUUID/" $OCFOLDER/config.plist
+
+# Support both GNU and BSD sed
+SEDOPTION=
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SEDOPTION="''"
+fi
+sed -i $SEDOPTION -e "s/MLB_PLACEHOLDER/$MLB/" \
+         -e "s/Serial_PLACEHOLDER/$SystemSerialNumber/" \
+         -e "s/SmUUID_PLACEHOLDER/$SystemUUID/" $OCFOLDER/config.plist
 
 # Remove unused UEFI Drivers
 find $OCFOLDER/Drivers ! -name OpenCanopy.efi \


### PR DESCRIPTION
**Closes issue** #


**What has been done in this PR ?**
Added script to run on both macOS as well as Linux. Tested on `macOS 13.0.1` and `Ubuntu 22.10`
Before, `sed` would fail, due to difference in arguments between GNU/BSD `sed` command